### PR TITLE
Make sure ambari-agent has started prior to starting services.

### DIFF
--- a/metron-deployment/vagrant/quick-dev-platform/Vagrantfile
+++ b/metron-deployment/vagrant/quick-dev-platform/Vagrantfile
@@ -16,7 +16,7 @@
 #
 require 'getoptlong'
 
-ansibleTags='hdp-deploy,metron'
+ansibleTags='ambari-agent,hdp-deploy,metron'
 ansibleSkipTags='solr,yaf'
 
 begin


### PR DESCRIPTION
We need this for quick-dev with 2.5.
