### PR TITLE
fixes for site-book and Kerberos-setup.md

### DIFF
--- a/metron-deployment/vagrant/Kerberos-setup.md
+++ b/metron-deployment/vagrant/Kerberos-setup.md
@@ -2,14 +2,14 @@
 **Note:** These are manual instructions for Kerberizing Metron Storm topologies from Kafka to Kafka. This does not cover the Ambari MPack, sensor connections, or MAAS.
 
 1. Build full dev and ssh into the machine
-```
+  ```
 cd incubator-metron/metron-deployment/vagrant/full-dev-platform
 vagrant up
 vagrant ssh
-```
+  ```
 
 2. Export env vars
-```
+  ```
 # execute as root
 sudo su -
 export ZOOKEEPER=node1
@@ -17,15 +17,15 @@ export BROKERLIST=node1
 export HDP_HOME="/usr/hdp/current"
 export METRON_VERSION="0.3.1"
 export METRON_HOME="/usr/metron/${METRON_VERSION}"
-```
+  ```
 
 3. Stop all topologies - we will  restart them again once Kerberos has been enabled.
-```
+  ```
 for topology in bro snort enrichment indexing; do storm kill $topology; done
-```
+  ```
 
 4. Setup Kerberos
-```
+  ```
 # Note: if you copy/paste this full set of commands, the kdb5_util command will not run as expected, so run the commands individually to ensure they all execute
 yum -y install krb5-server krb5-libs krb5-workstation
 sed -i 's/kerberos.example.com/node1/g' /etc/krb5.conf
@@ -36,97 +36,106 @@ kdb5_util create -s
 /etc/rc.d/init.d/kadmin start
 chkconfig krb5kdc on
 chkconfig kadmin on
-```
+  ```
 
 5. Setup the admin and metron user principals. You'll kinit as the metron user when running topologies. Make sure to remember the passwords.
-```
+  ```
 kadmin.local -q "addprinc admin/admin"
 kadmin.local -q "addprinc metron"
-```
+  ```
 
 6. Create the metron user HDFS home directory
-```
+  ```
 sudo -u hdfs hdfs dfs -mkdir /user/metron && \
 sudo -u hdfs hdfs dfs -chown metron:hdfs /user/metron && \
 sudo -u hdfs hdfs dfs -chmod 770 /user/metron
-```
+  ```
 
-7. In Ambari, setup Storm to run with Kerberos and run worker jobs as the submitting user. Add the following properties to custom storm-site. In the Storm config section in Ambari, choose “Add Property” under custom storm-site. In the dialog window, choose the “bulk property add mode” toggle button and add the below values.
-```
+7. In Ambari, setup Storm to run with Kerberos and run worker jobs as the submitting user:
+
+  a. Add the following properties to custom storm-site:
+    ```
 topology.auto-credentials=['org.apache.storm.security.auth.kerberos.AutoTGT']
 nimbus.credential.renewers.classes=['org.apache.storm.security.auth.kerberos.AutoTGT']
 supervisor.run.worker.as.user=true
-```
+    ```
 
-![custom storm-site](readme-images/ambari-storm-site.png)
+  b. In the Storm config section in Ambari, choose “Add Property” under custom storm-site:
 
-![custom storm-site properties](readme-images/ambari-storm-site-properties.png)
+    ![custom storm-site](readme-images/ambari-storm-site.png)
+
+  c. In the dialog window, choose the “bulk property add mode” toggle button and add the below values:
+
+    ![custom storm-site properties](readme-images/ambari-storm-site-properties.png)
 
 8. Kerberize the cluster via Ambari. More detailed documentation can be found [here](http://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.5.3/bk_security/content/_enabling_kerberos_security_in_ambari.html).
-   1. For this exercise, choose existing MIT KDC (this is what we setup and installed in the previous steps.)
+
+  a. For this exercise, choose existing MIT KDC (this is what we setup and installed in the previous steps.)
       ![enable keberos](readme-images/enable-kerberos.png)
       ![enable keberos get started](readme-images/enable-kerberos-started.png)
-   2. Setup Kerberos configuration. Realm is EXAMPLE.COM. The admin principal will end up as admin/admin@EXAMPLE.COM when testing the KDC. Use the password you entered during the step for adding the admin principal.
+
+  b. Setup Kerberos configuration. Realm is EXAMPLE.COM. The admin principal will end up as admin/admin@EXAMPLE.COM when testing the KDC. Use the password you entered during the step for adding the admin principal.
       ![enable keberos configure](readme-images/enable-kerberos-configure-kerberos.png)
-   3. Click through to “Start and Test Services.” Let the cluster spin up, but don't worry about starting up Metron via Ambari - we're going to run the parsers manually against the rest of the Hadoop cluster Kerberized. The wizard will fail at starting Metron, but this is OK. Click “continue.” When you’re finished, the custom storm-site should look similar to the following:
+
+  c. Click through to “Start and Test Services.” Let the cluster spin up, but don't worry about starting up Metron via Ambari - we're going to run the parsers manually against the rest of the Hadoop cluster Kerberized. The wizard will fail at starting Metron, but this is OK. Click “continue.” When you’re finished, the custom storm-site should look similar to the following:
       ![enable keberos configure](readme-images/custom-storm-site-final.png)
 
 9. Setup Metron keytab
-```
+  ```
 kadmin.local -q "ktadd -k metron.headless.keytab metron@EXAMPLE.COM" && \
 cp metron.headless.keytab /etc/security/keytabs && \
 chown metron:hadoop /etc/security/keytabs/metron.headless.keytab && \
 chmod 440 /etc/security/keytabs/metron.headless.keytab
-```
+  ```
 
 10. Kinit with the metron user
-```
+  ```
 kinit -kt /etc/security/keytabs/metron.headless.keytab metron@EXAMPLE.COM
-```
+  ```
 
 11. First create any additional Kafka topics you will need. We need to create the topics before adding the required ACLs. The current full dev installation will deploy bro, snort, enrichments, and indexing only. e.g.
-```
+  ```
 ${HDP_HOME}/kafka-broker/bin/kafka-topics.sh --zookeeper $ZOOKEEPER:2181 --create --topic yaf --partitions 1 --replication-factor 1
-```
+  ```
 
 12. Setup Kafka ACLs for the topics
-```
+  ```
 export KERB_USER=metron;
 for topic in bro enrichments indexing snort; do
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --topic ${topic};
 done;
-```
+  ```
 
 13. Setup Kafka ACLs for the consumer groups
-```
+  ```
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --group bro_parser;
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --group snort_parser;
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --group yaf_parser;
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --group enrichments;
 ${HDP_HOME}/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --group indexing;
-```
+  ```
 
 14. Add metron user to the Kafka cluster ACL
-```
+  ```
 /usr/hdp/current/kafka-broker/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=node1:2181 --add --allow-principal User:${KERB_USER} --cluster kafka-cluster
-```
+  ```
 
 15. We also need to grant permissions to the HBase tables. Kinit as the hbase user and add ACLs for metron.
-```
+  ```
 kinit -kt /etc/security/keytabs/hbase.headless.keytab hbase-metron_cluster@EXAMPLE.COM
 echo "grant 'metron', 'RW', 'threatintel'" | hbase shell
 echo "grant 'metron', 'RW', enrichment" | hbase shell
-```
+  ```
 
 16. Create a “.storm” directory in the metron user’s home directory and switch to that directory.
-```
+  ```
 su - metron
 mkdir .storm
 cd .storm
-```
+  ```
 
 17. Create a custom client jaas file. This should look identical to the Storm client jaas file located in /etc/storm/conf/client_jaas.conf except for the addition of a Client stanza. The Client stanza is used for Zookeeper. All quotes and semicolons are necessary.
-```
+  ```
 [metron@node1 .storm]$ cat client_jaas.conf
 StormClient {
    com.sun.security.auth.module.Krb5LoginModule required
@@ -146,59 +155,60 @@ KafkaClient {
    renewTicket=true
    serviceName="kafka";
 };
-```
+  ```
 
 18. Create a storm.yaml with jaas file info.
-```
+  ```
 [metron@node1 .storm]$ cat storm.yaml
 nimbus.seeds : ['node1']
 java.security.auth.login.config : '/home/metron/.storm/client_jaas.conf'
 storm.thrift.transport : 'org.apache.storm.security.auth.kerberos.KerberosSaslTransportPlugin'
-```
+  ```
 
 19. Create an auxiliary storm configuration json file in the metron user’s home directory. Note the login config option in the file points to our custom client_jaas.conf.
-```
+  ```
 cd /home/metron
 [metron@node1 ~]$ cat storm-config.json
 {
   "topology.worker.childopts" : "-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf"
 }
-```
+  ```
 
 20. Setup enrichment and indexing.
-    1. Modify enrichment.properties - `${METRON_HOME}/config/enrichment.properties`
-```
-kafka.security.protocol=PLAINTEXTSASL
-topology.worker.childopts=-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf
-```
 
-    2. Modify elasticsearch.properties - `${METRON_HOME}/config/elasticsearch.properties`
-```
+  a. Modify enrichment.properties - `${METRON_HOME}/config/enrichment.properties`
+    ```
 kafka.security.protocol=PLAINTEXTSASL
 topology.worker.childopts=-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf
-```
+    ```
+
+  b. Modify elasticsearch.properties - `${METRON_HOME}/config/elasticsearch.properties`
+    ```
+kafka.security.protocol=PLAINTEXTSASL
+topology.worker.childopts=-Djava.security.auth.login.config=/home/metron/.storm/client_jaas.conf
+    ```
 
 21. Restart the parser topologies. Be sure to pass in the new parameter, “-ksp” or “--kafka_security_protocol.” Run this from the metron home directory.
-```
+  ```
 for parser in bro snort; do ${METRON_HOME}/bin/start_parser_topology.sh -z node1:2181 -s ${parser} -ksp PLAINTEXTSASL -e storm-config.json; done
-```
+  ```
 
 22. Now restart the enrichment and indexing topologies.
-```
+  ```
 ${METRON_HOME}/bin/start_enrichment_topology.sh
 ${METRON_HOME}/bin/start_elasticsearch_topology.sh
-```
+  ```
 
 23. Push some sample data to one of the parser topics. E.g for yaf we took raw data from [incubator-metron/metron-platform/metron-integration-test/src/main/sample/data/yaf/raw/YafExampleOutput](../../metron-platform/metron-integration-test/src/main/sample/data/yaf/raw/YafExampleOutput)
-```
+  ```
 cat sample-yaf.txt | ${HDP_HOME}/kafka-broker/bin/kafka-console-producer.sh --broker-list node1:6667 --security-protocol PLAINTEXTSASL --topic yaf
-```
+  ```
 
 24. Wait a few moments for data to flow through the system and then check for data in the Elasticsearch indexes. Replace yaf with whichever parser type you’ve chosen.
-```
+  ```
 curl -XGET "node1:9200/yaf*/_search"
 curl -XGET "node1:9200/yaf*/_count"
-```
+  ```
 
 25. You should have data flowing from the parsers all the way through to the indexes. This completes the Kerberization instructions
 

--- a/metron-deployment/vagrant/README.md
+++ b/metron-deployment/vagrant/README.md
@@ -1,5 +1,6 @@
 # Vagrant Deployment
 
+- Kerberos Setup
 - Codelab Platform
 - Fast CAPA Test Platform
 - Full Dev Platform

--- a/site-book/bin/generate-md.sh
+++ b/site-book/bin/generate-md.sh
@@ -49,6 +49,7 @@ EXCLUSION_LIST=(
     '/site/'
     '/site-book/'
     '/build_utils/'
+    '/\.github/'
 )
 
 ## This is a list of resources (eg .png files) needed to render the markdown files.
@@ -71,12 +72,12 @@ RESOURCE_LIST=(
 ## that needs an href re-written to match a resource in the images/ directory.  Odd fields are the corresponding
 ## one-line sed script, in single quotes, that does the rewrite.  See below for examples.
 HREF_REWRITE_LIST=(
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/ambari-storm-site-properties.png)#(../../images/ambari-storm-site-properties.png)#g'
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/ambari-storm-site.png)#(../../images/ambari-storm-site.png)#g'
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/custom-storm-site-final.png)#(../../images/custom-storm-site-final.png)#g'
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/enable-kerberos-configure-kerberos.png)#(../../images/enable-kerberos-configure-kerberos.png)#g'
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/enable-kerberos-started.png)#(../../images/enable-kerberos-started.png)#g'
-    metron-deployment/vagrant/KERBEROS_SETUP.md 's#(readme-images/enable-kerberos.png)#(../../images/enable-kerberos.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/ambari-storm-site-properties.png)#(../../images/ambari-storm-site-properties.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/ambari-storm-site.png)#(../../images/ambari-storm-site.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/custom-storm-site-final.png)#(../../images/custom-storm-site-final.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/enable-kerberos-configure-kerberos.png)#(../../images/enable-kerberos-configure-kerberos.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/enable-kerberos-started.png)#(../../images/enable-kerberos-started.png)#g'
+    metron-deployment/vagrant/Kerberos-setup.md 's#(readme-images/enable-kerberos.png)#(../../images/enable-kerberos.png)#g'
     metron-platform/metron-enrichment/README.md 's#(enrichment_arch.png)#(../../images/enrichment_arch.png)#g'
     metron-platform/metron-indexing/README.md 's#(indexing_arch.png)#(../../images/indexing_arch.png)#g'
     metron-platform/metron-parsers/README.md 's#(parser_arch.png)#(../../images/parser_arch.png)#g'


### PR DESCRIPTION
Hey Mike, these mods fix the indent problems, as noted in my comment to PR#497, and a couple other details I noticed along the way.
You can squash without attribution.

Be careful with the merge, as when I started from your stuff I got weirdness with path 
* metron-docker/compose/kafkazk/{common,enrichment,parser}
--Matt