### PR TITLE
ElasticsearchIndexingIntegrationTest was deeply broken

### DIFF
--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/components/ElasticSearchComponent.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/components/ElasticSearchComponent.java
@@ -105,10 +105,6 @@ public class ElasticSearchComponent implements InMemoryComponent {
   private Map<String, String> extraElasticSearchSettings;
   private List<Mapping> mappings;
 
-  public ElasticSearchComponent(int httpPort, File indexDir, List<Mapping> mappings) {
-    this(httpPort, indexDir, null, Collections.EMPTY_LIST);
-  }
-
   public ElasticSearchComponent(int httpPort, File indexDir,
       Map<String, String> extraElasticSearchSettings, List<Mapping> mappings) {
     this.httpPort = httpPort;

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -56,8 +56,8 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
   protected String sampleParsedPath = TestConstants.SAMPLE_DATA_PARSED_PATH + "TestExampleParsed";
   protected String fluxPath = "../metron-indexing/src/main/flux/indexing/remote.yaml";
   protected String testSensorType = "test";
-
-
+  protected final int NUM_RETRIES = 100;
+  protected final long TOTAL_TIME_MS = 150000L;
   public static List<Map<String, Object>> readDocsFromDisk(String hdfsDirStr) throws IOException {
     List<Map<String, Object>> ret = new ArrayList<>();
     File hdfsDir = new File(hdfsDirStr);
@@ -180,8 +180,8 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
             .withComponent("storm", fluxComponent)
             .withComponent("search", getSearchComponent(topologyProperties))
             .withMillisecondsBetweenAttempts(1500)
-            .withNumRetries(100)
-            .withMaxTimeMS(150000)
+            .withNumRetries(NUM_RETRIES)
+            .withMaxTimeMS(TOTAL_TIME_MS)
             .withCustomShutdownOrder(new String[] {"search","storm","config","kafka","zk"})
             .build();
 
@@ -198,8 +198,6 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
       // on the field name converter
       assertInputDocsMatchOutputs(inputDocs, docs, getFieldNameConverter());
       assertInputDocsMatchOutputs(inputDocs, readDocsFromDisk(hdfsDir), x -> x);
-    } catch(Throwable e) {
-      e.printStackTrace();
     }
     finally {
       if(runner != null) {

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -66,6 +66,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${global_log4j_core_version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${global_log4j_core_version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-core</artifactId>
             <version>${global_storm_version}</version>


### PR DESCRIPTION
We were catching throwable AND the isn field for yaf was variously a text and a long, so it was having trouble merging the types.  It was also swallowing the exception, so that's double plus bad.